### PR TITLE
Add a 10 percent offset to cache duration

### DIFF
--- a/Enferno.Public.Test/App.config
+++ b/Enferno.Public.Test/App.config
@@ -47,7 +47,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Unity.Abstractions" publicKeyToken="489b6accfaf20ef0" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+        <bindingRedirect oldVersion="0.0.0.0-5.11.7.0" newVersion="5.11.7.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="CommonServiceLocator" publicKeyToken="489b6accfaf20ef0" culture="neutral" />
@@ -55,7 +55,15 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Unity.Container" publicKeyToken="489b6accfaf20ef0" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.9.5.0" newVersion="5.9.5.0" />
+        <bindingRedirect oldVersion="0.0.0.0-5.11.11.0" newVersion="5.11.11.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Enferno.Public.Test/CacheManagerTests.cs
+++ b/Enferno.Public.Test/CacheManagerTests.cs
@@ -1,5 +1,4 @@
-﻿
-using Enferno.Public.Caching;
+﻿using Enferno.Public.Caching;
 using Enferno.Public.Caching.Configuration;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -9,33 +8,100 @@ namespace Enferno.Public.Test
     {
         public int Id { get; set; }
     }
+
     public class ObjectWithAnIdAndData
     {
         public int Id { get; set; }
-        public string Data{ get; set; }
+        public string Data { get; set; }
     }
 
     [TestClass]
     public class CacheManagerTests
     {
-         [TestMethod, TestCategory("UnitTest")]
-        public void CacheConfigDurationTest()
+        [TestMethod, TestCategory("UnitTest")]
+        public void CacheConfigDefaultDurationTest()
         {
             // Arrange
             const string cacheName = "AccessClient";
 
             var cache = new InMemoryTestCache(cacheName);
             var unused = new CacheManager(cache);
-            
+
             //Assert
-            Assert.AreEqual(5, CacheConfiguration.Instance(cacheName).DefaultDuration, "Default duration");
-            Assert.AreEqual(5, CacheConfiguration.Instance(cacheName).GetCacheTime("GetEntityWithDefaultDuration"), "Item with default duration");
-            Assert.AreEqual(1, CacheConfiguration.Instance(cacheName).GetCacheTime("GetEntityWith1MinuteDuration"), "Item 1 min duration");
-            Assert.AreEqual(0, CacheConfiguration.Instance(cacheName).GetCacheTime("GetEntityWithZeroDuration"), "Item 0 duration");
-            Assert.AreEqual(0, CacheConfiguration.Instance(cacheName).GetCacheTime("NonExistingItem"), "Non-existing 0 duration");    
+            Assert.AreEqual(300, CacheConfiguration.Instance(cacheName).DefaultDuration, "Default duration");
         }
 
-         [TestMethod, TestCategory("UnitTest")]
+        [TestMethod, TestCategory("UnitTest")]
+        public void CacheConfigGetEntityWithDefaultDurationDurationTest()
+        {
+            // Arrange
+            const string cacheName = "AccessClient";
+
+            var cache = new InMemoryTestCache(cacheName);
+            var unused = new CacheManager(cache);
+
+            //Assert
+            var betweenTestData = new BetweenTestData
+            {
+                Actual = CacheConfiguration.Instance(cacheName).GetCacheTime("GetEntityWithDefaultDuration"),
+
+                MinValue = 270,
+                MaxValue = 330
+                
+            };
+            Assert.IsTrue(betweenTestData.IsValid, $"Item with default duration: {betweenTestData.GetErrorMessage()}");
+        }
+
+        [TestMethod, TestCategory("UnitTest")]
+        public void CacheConfigGetEntityWith1MinuteDurationDurationTest()
+        {
+            // Arrange
+            const string cacheName = "AccessClient";
+
+            var cache = new InMemoryTestCache(cacheName);
+            var unused = new CacheManager(cache);
+
+            var offsetted60SecondsDuration = CacheConfiguration.Instance(cacheName).GetCacheTime("GetEntityWith1MinuteDuration");
+
+            var betweenTestData = new BetweenTestData
+            {
+                Actual = offsetted60SecondsDuration,
+
+                MinValue = 54,
+                MaxValue = 66
+                
+            };
+            Assert.IsTrue(betweenTestData.IsValid, $"Item 1 min duration {betweenTestData.GetErrorMessage()}");
+
+        }
+
+        [TestMethod, TestCategory("UnitTest")]
+        public void CacheConfigGetEntityWithZeroDurationDurationTest()
+        {
+            // Arrange
+            const string cacheName = "AccessClient";
+
+            var cache = new InMemoryTestCache(cacheName);
+            var unused = new CacheManager(cache);
+
+            //Assert
+            Assert.AreEqual(0, CacheConfiguration.Instance(cacheName).GetCacheTime("GetEntityWithZeroDuration"), "Item 0 duration");
+        }
+
+        [TestMethod, TestCategory("UnitTest")]
+        public void CacheConfigNonExistingItemDurationTest()
+        {
+            // Arrange
+            const string cacheName = "AccessClient";
+
+            var cache = new InMemoryTestCache(cacheName);
+            var unused = new CacheManager(cache);
+
+            //Assert
+            Assert.AreEqual(0, CacheConfiguration.Instance(cacheName).GetCacheTime("NonExistingItem"), "Non-existing 0 duration");
+        }
+
+        [TestMethod, TestCategory("UnitTest")]
         public void CacheConfigDurationWhenNoFileTest()
         {
             // Arrange
@@ -49,7 +115,7 @@ namespace Enferno.Public.Test
             Assert.AreEqual(0, CacheConfiguration.Instance(cacheName).GetCacheTime("WhatEver"));
         }
 
-         [TestMethod, TestCategory("UnitTest")]
+        [TestMethod, TestCategory("UnitTest")]
         public void GetBasketWithExecuteFunctionWithRedirectTest()
         {
             const string cacheName = "AccessClient";
@@ -67,12 +133,12 @@ namespace Enferno.Public.Test
             // Assert
             Assert.AreSame(cached, basket);
             Assert.IsTrue(cacheManager.TryGet(cacheName, cacheKeyBasket, out cached));
-            
+
             Assert.IsTrue(cache.TryGet("Basket1", out cached));
             Assert.AreSame(cached, basket);
         }
 
-         [TestMethod, TestCategory("UnitTest")]
+        [TestMethod, TestCategory("UnitTest")]
         public void GetBasketWithExecuteFunctionWithRedirectAndClearTest()
         {
             const string cacheName = "AccessClient";
@@ -97,7 +163,7 @@ namespace Enferno.Public.Test
             Assert.IsTrue(cacheManager.TryGet(cacheName, cacheKeyCheckout, out cachedCheckout));
 
             // Act 2
-            var modifiedBasket = new ObjectWithAnId {Id = basketId};
+            var modifiedBasket = new ObjectWithAnId { Id = basketId };
             var cacheKeyInsert = cacheManager.GetKey("InsertBasketItem", modifiedBasket.Id);
             cacheManager.Add(cacheName, cacheKeyInsert, modifiedBasket);
 
@@ -107,7 +173,7 @@ namespace Enferno.Public.Test
             Assert.AreSame(cachedBasket, modifiedBasket);
         }
 
-         [TestMethod, TestCategory("UnitTest")]
+        [TestMethod, TestCategory("UnitTest")]
         public void FlushItemsByTagTest()
         {
             // Arrange
@@ -119,9 +185,9 @@ namespace Enferno.Public.Test
 
             // Act
             var key = cacheManager.GetKey("GetSomethingWithFlush", 1);
-            var somethingIn = new ObjectWithAnId {Id = 1};
+            var somethingIn = new ObjectWithAnId { Id = 1 };
             var somethingOut = cacheManager.ExecuteFunction(cacheName, key, "Tag" + 1, () => somethingIn);
-            Assert.IsTrue(cacheManager.TryGet(cacheName, key,  out ObjectWithAnId _));
+            Assert.IsTrue(cacheManager.TryGet(cacheName, key, out ObjectWithAnId _));
 
             key = cacheManager.GetKey("GetWhateverWithFlush", 1);
             const int whateverIn = 1;
@@ -132,7 +198,7 @@ namespace Enferno.Public.Test
             var somethingIn2 = new ObjectWithAnId { Id = 2 };
             var somethingOut2 = cacheManager.ExecuteFunction(cacheName, key, "Tag" + 2, () => somethingIn2);
             Assert.IsTrue(cacheManager.TryGet(cacheName, key, out ObjectWithAnId _));
-            
+
             // Assert 1
             Assert.AreSame(somethingIn, somethingOut);
             Assert.AreEqual(whateverIn, whateverOut);
@@ -153,21 +219,21 @@ namespace Enferno.Public.Test
             Assert.IsTrue(cacheManager.TryGet(cacheName, key, out ObjectWithAnId _));
         }
 
-         [TestMethod, TestCategory("UnitTest")]
+        [TestMethod, TestCategory("UnitTest")]
         public void GetNullDataAndThenFlushItToCreateNew()
         {
             // Arrange
             const string cacheName = "AccessClient";
             const string email = "patrik@attentia.se";
-            var newObject = new ObjectWithAnId {Id = 1};
+            var newObject = new ObjectWithAnId { Id = 1 };
 
             var cache = new InMemoryTestCache(cacheName);
             var cacheManager = new CacheManager(cache);
 
             var cacheKey = cacheManager.GetKey("GetCustomerByEmail", email);
-            
+
             //Act
-            if(!cacheManager.HasConfiguration(cacheName)) Assert.Fail("Should have a cache config file");
+            if (!cacheManager.HasConfiguration(cacheName)) Assert.Fail("Should have a cache config file");
             var added = cacheManager.Add(cacheName, cacheKey, (ObjectWithAnId)null);
             Assert.IsFalse(added, "Should not be added.");
 
@@ -185,7 +251,7 @@ namespace Enferno.Public.Test
             Assert.AreSame(newObject, cached, "Now it should be cached.");
         }
 
-         [TestMethod, TestCategory("UnitTest")]
+        [TestMethod, TestCategory("UnitTest")]
         public void GetBasketThenInsertWithCacheRefresh()
         {
             // Arrange
@@ -224,13 +290,13 @@ namespace Enferno.Public.Test
             Assert.IsNull(cached, "Checkout should have been flushed");
         }
 
-         [TestMethod, TestCategory("UnitTest")]
+        [TestMethod, TestCategory("UnitTest")]
         public void GetCustomerThenUpdateWithRedirectFormatTest()
         {
             // Arrange
             const string cacheName = "AccessClient";
             const int customerId = 1;
-            var existingCustomer = new ObjectWithAnIdAndData { Id = customerId, Data = "Data1"};
+            var existingCustomer = new ObjectWithAnIdAndData { Id = customerId, Data = "Data1" };
 
             var cache = new InMemoryTestCache(cacheName);
             var cacheManager = new CacheManager(cache);
@@ -252,7 +318,8 @@ namespace Enferno.Public.Test
             success = cacheManager.TryGet(cacheName, cacheKeyCustomer, out object _);
             Assert.IsFalse(success, "customer should have been flushed.");
         }
-         [TestMethod, TestCategory("UnitTest")]
+
+        [TestMethod, TestCategory("UnitTest")]
         public void GetCustomerThenUpdateWithRefreshFormatTest()
         {
             // Arrange
@@ -281,7 +348,7 @@ namespace Enferno.Public.Test
             Assert.AreSame(updatedCustomer, cached, "Should be the same in the cache after update");
         }
 
-         [TestMethod, TestCategory("UnitTest")]
+        [TestMethod, TestCategory("UnitTest")]
         public void FlushItemsByMultipleDependencyNamesTest()
         {
             // Arrange
@@ -320,4 +387,18 @@ namespace Enferno.Public.Test
             Assert.IsFalse(cacheManager.TryGet(cacheName, cacheManager.GetKey("GetWhateverWithFlush", 2), out int _));
         }
     }
+    
+    internal class BetweenTestData
+    {
+        public int MaxValue { get; set; }
+        public int MinValue { get; set; }
+        public int Actual { get; set; }
+
+        public bool IsValid => MaxValue >= Actual && Actual >= MinValue;
+        public string GetErrorMessage()
+        {
+            return $"Expected: {MaxValue} >= Actual >= {MinValue} Actual: <{Actual}>.";
+        }
+    }
+    
 }

--- a/Enferno.Public.Test/Enferno.Public.Test.csproj
+++ b/Enferno.Public.Test/Enferno.Public.Test.csproj
@@ -23,6 +23,7 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
     <TargetFrameworkProfile />
+    <LangVersion>default</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Enferno.Public.Test/Enferno.Public.Test.csproj
+++ b/Enferno.Public.Test/Enferno.Public.Test.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Enferno.Public.Test</RootNamespace>
     <AssemblyName>Enferno.Public.Test</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
@@ -49,24 +49,28 @@
     <Reference Include="Microsoft.Practices.EnterpriseLibrary.Logging, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\EnterpriseLibrary.Logging.6.0.1304.0\lib\NET45\Microsoft.Practices.EnterpriseLibrary.Logging.dll</HintPath>
     </Reference>
+    <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Runtime.Caching" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.2\lib\netstandard1.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Remoting" />
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.ValueTuple.4.5.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
     </Reference>
-    <Reference Include="Unity.Abstractions, Version=4.0.3.0, Culture=neutral, PublicKeyToken=489b6accfaf20ef0, processorArchitecture=MSIL">
-      <HintPath>..\packages\Unity.Abstractions.4.0.3\lib\net45\Unity.Abstractions.dll</HintPath>
+    <Reference Include="Unity.Abstractions, Version=5.11.7.0, Culture=neutral, PublicKeyToken=489b6accfaf20ef0, processorArchitecture=MSIL">
+      <HintPath>..\packages\Unity.Abstractions.5.11.7\lib\net47\Unity.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Unity.Configuration, Version=5.9.1.0, Culture=neutral, PublicKeyToken=489b6accfaf20ef0, processorArchitecture=MSIL">
-      <HintPath>..\packages\Unity.Configuration.5.9.1\lib\net45\Unity.Configuration.dll</HintPath>
+    <Reference Include="Unity.Configuration, Version=5.11.2.0, Culture=neutral, PublicKeyToken=489b6accfaf20ef0, processorArchitecture=MSIL">
+      <HintPath>..\packages\Unity.Configuration.5.11.2\lib\net47\Unity.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Unity.Container, Version=5.9.5.0, Culture=neutral, PublicKeyToken=489b6accfaf20ef0, processorArchitecture=MSIL">
-      <HintPath>..\packages\Unity.Container.5.9.5\lib\net45\Unity.Container.dll</HintPath>
+    <Reference Include="Unity.Container, Version=5.11.11.0, Culture=neutral, PublicKeyToken=489b6accfaf20ef0, processorArchitecture=MSIL">
+      <HintPath>..\packages\Unity.Container.5.11.11\lib\net47\Unity.Container.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Choose>

--- a/Enferno.Public.Test/packages.config
+++ b/Enferno.Public.Test/packages.config
@@ -2,9 +2,10 @@
 <packages>
   <package id="EnterpriseLibrary.Common" version="6.0.1304.0" targetFramework="net45" />
   <package id="EnterpriseLibrary.Logging" version="6.0.1304.0" targetFramework="net45" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" targetFramework="net45" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net472" />
+  <package id="Unity.Abstractions" version="5.11.7" targetFramework="net472" />
+  <package id="Unity.Configuration" version="5.11.2" targetFramework="net472" />
+  <package id="Unity.Container" version="5.11.11" targetFramework="net472" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net45" />
-  <package id="Unity.Abstractions" version="4.0.3" targetFramework="net45" />
-  <package id="Unity.Configuration" version="5.9.1" targetFramework="net45" />
-  <package id="Unity.Container" version="5.9.5" targetFramework="net45" />
 </packages>

--- a/Enferno.Public/App.config
+++ b/Enferno.Public/App.config
@@ -25,11 +25,19 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Unity.Abstractions" publicKeyToken="489b6accfaf20ef0" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+        <bindingRedirect oldVersion="0.0.0.0-5.11.7.0" newVersion="5.11.7.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Unity.Container" publicKeyToken="489b6accfaf20ef0" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.9.5.0" newVersion="5.9.5.0" />
+        <bindingRedirect oldVersion="0.0.0.0-5.11.11.0" newVersion="5.11.11.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Enferno.Public/Caching/BaseCache.cs
+++ b/Enferno.Public/Caching/BaseCache.cs
@@ -21,7 +21,7 @@ namespace Enferno.Public.Caching
     public abstract class BaseCache : ICache
     {
         public string Name { get; protected set; }
-        public int? DurationMinutes { get; set; }
+        public int? DurationSeconds { get; set; }
 
         protected static readonly NullObject CacheNullObject = new NullObject();
 
@@ -96,13 +96,13 @@ namespace Enferno.Public.Caching
             /*NOOP*/
         }
 
-        private TimeSpan GetDurationTimeSpan(int? durationMinutes)
+        private TimeSpan GetDurationTimeSpan(int? durationSeconds)
         {
-            var duration = durationMinutes.HasValue && durationMinutes.Value != 0
-                ? TimeSpan.FromMinutes(durationMinutes.Value)
-                : DurationMinutes.HasValue
-                    ? TimeSpan.FromMinutes(DurationMinutes.Value)
-                    : TimeSpan.FromMinutes(5);
+            var duration = durationSeconds.HasValue && durationSeconds.Value != 0
+                ? TimeSpan.FromSeconds(durationSeconds.Value)
+                : DurationSeconds.HasValue
+                    ? TimeSpan.FromSeconds(DurationSeconds.Value)
+                    : TimeSpan.FromSeconds(5*60);
             return duration;
         }
     }

--- a/Enferno.Public/Caching/CacheManager.cs
+++ b/Enferno.Public/Caching/CacheManager.cs
@@ -40,7 +40,10 @@ namespace Enferno.Public.Caching
                 if (Caches.ContainsKey(cache.Name)) continue;
                 Caches.Add(cache.Name, cache);
                 Configurations.Add(cache.Name, CacheConfiguration.Instance(cache.Name));
-                if (!cache.DurationMinutes.HasValue) cache.DurationMinutes = CacheConfiguration.Instance(cache.Name).DefaultDuration;
+                if (!cache.DurationSeconds.HasValue)
+                {
+                    cache.DurationSeconds = CacheConfiguration.Instance(cache.Name).DefaultDuration;
+                }
             }
         }
 

--- a/Enferno.Public/Caching/ICache.cs
+++ b/Enferno.Public/Caching/ICache.cs
@@ -4,7 +4,7 @@ namespace Enferno.Public.Caching
     public interface ICache
     {
         string Name { get; }
-        int? DurationMinutes { get; set; }
+        int? DurationSeconds { get; set; }
         bool TryGet<T>(string key, out T cached);
         void Add<T>(string key, T cached, int? durationminutes = null);
         void Add<T>(string key, T cached, string dependencyName = null, int? durationMinutes = null);

--- a/Enferno.Public/Caching/InMemoryCache.cs
+++ b/Enferno.Public/Caching/InMemoryCache.cs
@@ -10,7 +10,7 @@ namespace Enferno.Public.Caching
 
         public InMemoryCache(string name, int duration) : base(name)
         {
-            DurationMinutes = duration;
+            DurationSeconds = duration;
             MyCache = InMemoryCacheFactory.GetCache(Name);
         }
 

--- a/Enferno.Public/Enferno.Public.csproj
+++ b/Enferno.Public/Enferno.Public.csproj
@@ -19,6 +19,7 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
     <TargetFrameworkProfile />
+    <LangVersion>default</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Enferno.Public/Enferno.Public.csproj
+++ b/Enferno.Public/Enferno.Public.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Enferno.Public</RootNamespace>
     <AssemblyName>Enferno.Public</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
@@ -52,6 +52,7 @@
     <Reference Include="Microsoft.Practices.EnterpriseLibrary.Logging, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\EnterpriseLibrary.Logging.6.0.1304.0\lib\NET45\Microsoft.Practices.EnterpriseLibrary.Logging.dll</HintPath>
     </Reference>
+    <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.configuration" />
@@ -59,24 +60,27 @@
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Runtime.Caching" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.2\lib\netstandard1.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.ValueTuple.4.5.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="Unity.Abstractions, Version=4.0.3.0, Culture=neutral, PublicKeyToken=489b6accfaf20ef0, processorArchitecture=MSIL">
-      <HintPath>..\packages\Unity.Abstractions.4.0.3\lib\net45\Unity.Abstractions.dll</HintPath>
+    <Reference Include="Unity.Abstractions, Version=5.11.7.0, Culture=neutral, PublicKeyToken=489b6accfaf20ef0, processorArchitecture=MSIL">
+      <HintPath>..\packages\Unity.Abstractions.5.11.7\lib\net47\Unity.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Unity.Configuration, Version=5.9.1.0, Culture=neutral, PublicKeyToken=489b6accfaf20ef0, processorArchitecture=MSIL">
-      <HintPath>..\packages\Unity.Configuration.5.9.1\lib\net45\Unity.Configuration.dll</HintPath>
+    <Reference Include="Unity.Configuration, Version=5.11.2.0, Culture=neutral, PublicKeyToken=489b6accfaf20ef0, processorArchitecture=MSIL">
+      <HintPath>..\packages\Unity.Configuration.5.11.2\lib\net47\Unity.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Unity.Container, Version=5.9.5.0, Culture=neutral, PublicKeyToken=489b6accfaf20ef0, processorArchitecture=MSIL">
-      <HintPath>..\packages\Unity.Container.5.9.5\lib\net45\Unity.Container.dll</HintPath>
+    <Reference Include="Unity.Container, Version=5.11.11.0, Culture=neutral, PublicKeyToken=489b6accfaf20ef0, processorArchitecture=MSIL">
+      <HintPath>..\packages\Unity.Container.5.11.11\lib\net47\Unity.Container.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Enferno.Public/packages.config
+++ b/Enferno.Public/packages.config
@@ -2,9 +2,10 @@
 <packages>
   <package id="EnterpriseLibrary.Common" version="6.0.1304.0" targetFramework="net45" />
   <package id="EnterpriseLibrary.Logging" version="6.0.1304.0" targetFramework="net45" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" targetFramework="net45" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net472" />
+  <package id="Unity.Abstractions" version="5.11.7" targetFramework="net472" />
+  <package id="Unity.Configuration" version="5.11.2" targetFramework="net472" />
+  <package id="Unity.Container" version="5.11.11" targetFramework="net472" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net45" />
-  <package id="Unity.Abstractions" version="4.0.3" targetFramework="net45" />
-  <package id="Unity.Configuration" version="5.9.1" targetFramework="net45" />
-  <package id="Unity.Container" version="5.9.5" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
- Use seconds precision instead of minutes
- Add a 10 percent offset to cache durations
- use latest language version
- updated tests to work with random durations 